### PR TITLE
get_frame can open both 'txy' and 'xyt' hdf5 layouts

### DIFF
--- a/holopy/core/marray.py
+++ b/holopy/core/marray.py
@@ -555,7 +555,15 @@ class ImageSequence(ImageSchema):
             return None
 
     def get_frame(self, n):
-        return Image(self.arr[..., n], spacing=self.image_spacing,
+        if self.arr.attrs.get('layout') == 'txy':
+            return Image(self.arr[n],
+                    spacing=self.image_spacing,
+                    optics=self.optics)
+        else:
+            # Assume the layout is 'xyt' because this is
+            # how the legacy camera controller code saved
+            # files.
+            return Image(self.arr[..., n], spacing=self.image_spacing,
                      optics=self.optics)
 
     def __iter__(self):


### PR DESCRIPTION
Tom and I decided that 'txy' would be a better layout for the camera gui image output because it enables us to treat images the way PIMS does. With the 'txy' layout, we can call image[0] and it conveniently returns the 0th image of the sequence. This patch to get_frame now can deal with both 'txy' and 'xyt' layouts for compatibility with both versions of the camera gui hdf5 output.
